### PR TITLE
Add Deploy on Railway documentation page

### DIFF
--- a/deployment/deploy-on-railway.mdx
+++ b/deployment/deploy-on-railway.mdx
@@ -1,0 +1,17 @@
+---
+title: 'Deploy on Railway'
+description: 'Learn how to deploy Chartbrew on Railway'
+canonicalUrl: https://docs.chartbrew.com/deployment/deploy-on-railway/
+
+meta: 
+    - property: og:url
+      content: https://docs.chartbrew.com/deployment/deploy-on-railway/
+
+---
+
+Chartbrew can be deployed on Railway using the 1-click template. This allows you to quickly set up and run Chartbrew with minimal configuration.
+
+
+<a href="https://railway.com/deploy/chartbrew?referralCode=9uHSFr&utm_medium=integration&utm_source=template&utm_campaign=generic" target="_blank" rel="noopener noreferrer">
+  <img src="https://railway.com/button.svg" alt="Deploy on Railway" height="40" noZoom />
+</a>

--- a/docs.json
+++ b/docs.json
@@ -30,7 +30,8 @@
               "deployment/deploy-with-apache",
               "deployment/deploy-on-heroku-and-vercel",
               "deployment/deploy-on-render",
-              "deployment/deploy-on-digitalocean"
+              "deployment/deploy-on-digitalocean",
+              "deployment/deploy-on-railway"
             ]
           },
           {


### PR DESCRIPTION
## Summary

- Add a new `deployment/deploy-on-railway` page with the Railway 1-click deploy button
- Register the page in `docs.json` under the Build section, following the same pattern as Deploy on DigitalOcean

## Test plan

- [ ] Run the docs site locally and confirm "Deploy on Railway" appears in the Build navigation
- [ ] Open `/deployment/deploy-on-railway` and verify the page renders correctly
- [ ] Click the Railway deploy button and confirm it opens the Chartbrew template on Railway